### PR TITLE
Support Show Full Subject in Compact View

### DIFF
--- a/compactHeadersApi.js
+++ b/compactHeadersApi.js
@@ -46,6 +46,13 @@ function install(window) {
   compactHeadersHideToolbar.setAttribute("tooltiptext", "Hides the header toolbar");
   compactHeadersHideToolbar.addEventListener("command", () => toggleToolbar());
 
+  let compactHeadersShowFullSubjectHeader = document.createXULElement("menuitem");
+  compactHeadersShowFullSubjectHeader.id = "compactHeadersShowFullSubjectHeader";
+  compactHeadersShowFullSubjectHeader.setAttribute("type", "checkbox");
+  compactHeadersShowFullSubjectHeader.setAttribute("label", "Show Full Subject");
+  compactHeadersShowFullSubjectHeader.setAttribute("tooltiptext", "Do not truncate Subject header in double line mode");
+  compactHeadersShowFullSubjectHeader.addEventListener("command", () => toggleFullSubjectHeader());
+
   let compactHeadersMoveToHeader = document.createXULElement("menuitem");
   compactHeadersMoveToHeader.id = "compactHeadersMoveToHeader";
   compactHeadersMoveToHeader.setAttribute("type", "checkbox");
@@ -179,6 +186,7 @@ function install(window) {
 
   compactHeadersPopup.append(compactHeadersSingleLine);
   compactHeadersPopup.append(compactHeadersSeparator3);
+  compactHeadersPopup.append(compactHeadersShowFullSubjectHeader);
   compactHeadersPopup.append(compactHeadersMoveToHeader);
   compactHeadersPopup.append(compactHeadersMoveCcHeader);
   compactHeadersPopup.append(compactHeadersMoveContentBaseheader);
@@ -286,7 +294,13 @@ function install(window) {
       messageHeader.children[i].setAttribute("style", "display: none;");
       if (messageHeader.getAttribute("singleline") != "singleline") headerSubjectSecurityContainer.setAttribute("style", "height: unset;");
     }
-    if (expandedsubjectBox) expandedsubjectBox.setAttribute("style", "overflow: hidden; -webkit-line-clamp: 1; max-width: fit-content;");
+    if (expandedsubjectBox) {
+      if ((messageHeader.getAttribute("showfullsubjectheader") != "showfullsubjectheader")) {
+        expandedsubjectBox.setAttribute("style", "overflow: hidden; -webkit-line-clamp: 1; max-width: fit-content;");
+      } else {
+        expandedsubjectBox.setAttribute("style", "overflow: hidden; -webkit-line-clamp: 3; max-width: fit-content;");
+      }
+    }
     if (messageHeader.getAttribute("singleline") == "singleline") singleLine();
     else doubleLine();
 
@@ -377,6 +391,15 @@ function install(window) {
       background: linear-gradient(to right,transparent,buttonface 2em) !important; min-width: max-content; min-height: 1.8em;");
   }
 
+  function toggleFullSubjectHeader() {
+    if (messageHeader.getAttribute("showfullsubjectheader") == "showfullsubjectheader") {
+      messageHeader.removeAttribute("showfullsubjectheader");
+    } else {
+      messageHeader.setAttribute("showfullsubjectheader", "showfullsubjectheader");
+    }
+    checkHeaders();
+  }
+
   function toggleToHeader() {
     if (messageHeader.getAttribute("movetoheader") == "movetoheader") {
       messageHeader.removeAttribute("movetoheader");
@@ -414,6 +437,11 @@ function install(window) {
   }
 
   function checkToCcHeaders() {
+    if (messageHeader.getAttribute("showfullsubjectheader") == "showfullsubjectheader") {
+      compactHeadersShowFullSubjectHeader.setAttribute("checked", true);
+    } else {
+      compactHeadersShowFullSubjectHeader.setAttribute("checked", false);
+    }
     if (messageHeader.getAttribute("movetoheader") == "movetoheader") {
       compactHeadersMoveToHeader.setAttribute("checked", true);
     } else {


### PR DESCRIPTION
Adds a new option `Show Full Subject`:
![kIZBU1fdAIpp8I6p](https://github.com/dillenger/compact-headers/assets/20227484/52c5ec38-8fa1-4883-a98f-43137bb1088f)

After enabling, the subject line will not be truncated:
![uYvA3xoa06N1vmYc](https://github.com/dillenger/compact-headers/assets/20227484/722e956a-45ec-417d-af08-1d83bf2c75bc)

