### PR TITLE
Show Recipients in To / CC header as Multiline If Having Display Name

### DIFF
--- a/compactHeadersApi.js
+++ b/compactHeadersApi.js
@@ -223,6 +223,18 @@ function install(window) {
       let style = document.createElement('style');
       style.id = "compactHeadersStyle";
       style.textContent = `
+#messageHeader[compact="compact"] :is(#headerSenderToolbarContainer, #expandedtoRow, #expandedccRow) {
+  min-width: 0;
+}
+
+#messageHeader[compact="compact"] :is(#expandedtoRow, #expandedccRow) .recipients-list {
+  flex-wrap: nowrap;
+}
+
+#messageHeader[compact="compact"] :is(#expandedtoRow, #expandedccRow) .recipients-list .header-recipient {
+  min-width: max-content;
+}
+
 #messageHeader[compact="compact"].message-header-show-sender-full-address :is(#expandedtoLabel, #toHeading, #expandedccLabel, #ccHeading) {
   align-self: center;
 }
@@ -342,19 +354,18 @@ function install(window) {
     headerViewToolbox.style.flex = "auto";
     headerViewToolbox.style.alignSelf = "auto";
 
-    let senderBoxHeight = expandedfromBox.offsetHeight;
     expandedfromRow.insertAdjacentElement("beforebegin", expandedcontentBaseRow);
     expandedcontentBaseRow.setAttribute("style", "background: linear-gradient(to right,transparent,buttonface 2em) !important;\
       margin-block: -1em; padding-block: 1em; margin-inline-start: -2em; padding-inline-start: 2.4em; z-index: 2; flex: inherit;");
-    expandedcontentBaseBox.setAttribute("style", `max-block-size: ${senderBoxHeight}px; min-height:18px; overflow: hidden; min-width: 250%; max-height: ${senderBoxHeight}px; margin-inline-end: -99em;`);
+    expandedcontentBaseBox.setAttribute("style", `min-height:18px; overflow: hidden; min-width: 250%; margin-inline-end: -99em;`);
     expandedfromRow.insertAdjacentElement("beforebegin", expandedccRow);
     expandedccRow.setAttribute("style", "background: linear-gradient(to right,transparent,buttonface 2em) !important;\
       margin-block: -1em; padding-block: 1em; margin-inline-start: -2em; padding-inline-start: 2.4em; z-index: 2; flex: inherit;");
-    expandedccBox.setAttribute("style", `max-block-size: ${senderBoxHeight}px; min-height:20px; overflow: hidden; min-width: 250%; max-height: ${senderBoxHeight}px; margin-inline-end: 1.6em;`);
+    expandedccBox.setAttribute("style", `min-height:20px; overflow: hidden; min-width: 250%; margin-inline-end: 1.6em;`);
     expandedfromRow.insertAdjacentElement("beforebegin", expandedtoRow);
     expandedtoRow.setAttribute("style", "background: linear-gradient(to right,transparent,buttonface 2em) !important;\
       margin-block: -1em; padding-block: 1em; margin-inline-start: -2em; padding-inline-start: 2.4em; z-index: 1; flex: inherit;");
-    expandedtoBox.setAttribute("style", `max-block-size: ${senderBoxHeight}px; min-height:20px; overflow: hidden; min-width: 250%; max-height: ${senderBoxHeight}px; margin-inline-end: 1.6em;`);
+    expandedtoBox.setAttribute("style", `min-height:20px; overflow: hidden; min-width: 250%; margin-inline-end: 1.6em;`);
 
     if ((messageHeader.getAttribute("movecontentbaseheader") != "movecontentbaseheader") || (messageHeader.getAttribute("singleline") == "singleline")) {
       expandedcontentBaseRow.style.display = "none";

--- a/compactHeadersApi.js
+++ b/compactHeadersApi.js
@@ -223,15 +223,15 @@ function install(window) {
       let style = document.createElement('style');
       style.id = "compactHeadersStyle";
       style.textContent = `
-#messageHeader[compact="compact"] :is(#expandedtoLabel, #toHeading, #expandedccLabel, #ccHeading) {
+#messageHeader[compact="compact"].message-header-show-sender-full-address :is(#expandedtoLabel, #toHeading, #expandedccLabel, #ccHeading) {
   align-self: center;
 }
 
-#messageHeader[compact="compact"] .has-display-name .recipient-single-line {
+#messageHeader[compact="compact"].message-header-show-sender-full-address .has-display-name .recipient-single-line {
   display: none;
 }
 
-#messageHeader[compact="compact"] .has-display-name .recipient-multi-line {
+#messageHeader[compact="compact"].message-header-show-sender-full-address .has-display-name .recipient-multi-line {
   display: inline-flex;
 }
 `;


### PR DESCRIPTION
When enabling `Show To Header`/`Show CC Header` in compact view, if the to/cc address has display name, it will be shown as multiline, to prevent that a too-long display name occupies most of the available space:

![BazwUBDUxO1Z8lS0](https://github.com/dillenger/compact-headers/assets/20227484/39fccbbe-72d4-4b47-85b1-cc278c2fae8b)

If the Address line does not contain sufficient space, the From Header is guaranteed to always fully display:

![5aR4YnP0l0e26crX](https://github.com/dillenger/compact-headers/assets/20227484/c76b4fbc-bf22-4662-a075-797c51366e5c)

---

Before this patch:

![Mjfu86VVV3NJyp6l](https://github.com/dillenger/compact-headers/assets/20227484/5c2837a2-661b-4aab-b7db-6cb756787186)
